### PR TITLE
Adding Snapshot capabilities for CHECKTABLE

### DIFF
--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -30,7 +30,8 @@ ALTER PROCEDURE [dbo].[DatabaseIntegrityCheck]
 @DatabasesInParallel nvarchar(max) = 'N',
 @LogToTable nvarchar(max) = 'N',
 @Execute nvarchar(max) = 'Y',
-@Resumable nvarchar(max) = 'N'
+@Resumable nvarchar(max) = 'N',
+@AllowSnapshots nvarchar(max) = 'Y'
 
 AS
 
@@ -173,7 +174,6 @@ BEGIN
                                   Selected bit)
 
   --Additions-------------------
-  DECLARE @sqlcmd nvarchar(max)
   DECLARE @dbtype nvarchar(max)
   DECLARE @avgRun int
   DECLARE @previousRunDate datetime
@@ -254,6 +254,7 @@ BEGIN
   SET @Parameters += ', @LogToTable = ' + ISNULL('''' + REPLACE(@LogToTable,'''','''''') + '''','NULL')
   SET @Parameters += ', @Execute = ' + ISNULL('''' + REPLACE(@Execute,'''','''''') + '''','NULL')
   SET @Parameters += ', @Resumable = ' + ISNULL('''' + REPLACE(@Resumable,'''','''''') + '''','NULL')
+  SET @Parameters += ', @AllowSnapshots = ' + ISNULL('''' + REPLACE(@AllowSnapshots,'''','''''') + '''','NULL')
 
   SET @StartMessage = 'Date and time: ' + CONVERT(nvarchar,@StartTime,120)
   RAISERROR('%s',10,1,@StartMessage) WITH NOWAIT
@@ -689,148 +690,6 @@ BEGIN
   OPTION (MAXRECURSION 0)
 
   ----------------------------------------------------------------------------------------------------
-  --// Update Persistent Table if we need to resume operations                                    //--
-  --// This is done here so the order can be updated appropriately                                //--
-  ----------------------------------------------------------------------------------------------------
-
-  IF @Resumable = 'Y'
-  BEGIN
-    WHILE 1=1
-    BEGIN
-      SELECT TOP 1 @CurrentDatabaseName = DatabaseName, @dbtype = DatabaseType, @agbit = AvailabilityGroup FROM @tmpDatabases WHERE Selected = 1 AND Completed = 0
-      IF @@ROWCOUNT = 0
-      BEGIN
-        BREAK
-      END
-      SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
-     
-     --Check if we need to create a snapshot
-      IF @agbit = 1
-      BEGIN
-      	select @role = s.role, @secondaryRoleAllowConnections = r.secondary_role_allow_connections
-	      from sys.databases d
-	      join sys.dm_hadr_availability_replica_states s on d.replica_id = s.replica_id
-	      join sys.availability_replicas r on s.replica_id = r.replica_id
-        where d.name = @CurrentDatabaseName
-
-        --role = 2 means secondary, secondaryRoleAllowConnections = 0 means non-readable secondary
-        IF @role = 2 and @secondaryRoleAllowConnections = 0
-        BEGIN
-          --We need a snapshot but first we need to make sure the database doesnt have mem opt tables for versions older than SQL 2019
-          IF @Version < 15
-          BEGIN
-            set @sqlcmd = 'IF EXISTS (SELECT * FROM sys.filegroups WHERE type = ''FX'') BEGIN SET @currentHasMemOptFG = 1 END ELSE BEGIN SET @currentHasMemOptFG = 0 END'
-            execute @CurrentDatabase_sp_executesql @stmt = @sqlcmd, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
-          END
-
-          IF @hasMemOptFG = 0 OR @hasMemOptFG IS NULL
-          BEGIN 
-            --Build and execute create snapshot statement
-            SET @snapNamePart = '_RollIntegChkInfo_ss_'
-            SET @snapName = @CurrentDatabaseName + @snapNamePart + CONVERT(nvarchar, @StartTime, 112)
-            SET @sqlcmd = 'CREATE DATABASE ' + QUOTENAME(@snapName) + ' ON '
-            SELECT @sqlcmd = @sqlcmd + '(Name = ' + QUOTENAME(name) + ', Filename = '''
-              + physical_name --+ CASE WHEN @SnapshotPath = 'DEFAULT' THEN physical_name ELSE @SnapshotPath + '\' + name END
-              + @snapNamePart + CONVERT(nvarchar, @StartTime, 112) + '''),'
-            FROM sys.master_files WHERE database_id = DB_ID(@CurrentDatabaseName) AND type = 0
-            SET @sqlcmd = LEFT(@sqlcmd, LEN(@sqlcmd) - 1)
-            SET @sqlcmd = @sqlcmd + ' AS SNAPSHOT OF ' + QUOTENAME(@CurrentDatabaseName)
-            EXEC sp_executesql @sqlcmd
-            SET @snapCreated = 1
-          END
-
-        END
-      END
-
-      --now that we've potentially created a snapshot, we need to use it if it was needed
-      IF @snapCreated = 1
-      BEGIN
-        SET @CurrentDatabase_sp_executesql = QUOTENAME(@snapName) + '.sys.sp_executesql'
-      END
-
-      SET @sqlcmd = 'SELECT DB_ID(''' + @CurrentDatabaseName + ''') as dbid, ''' + @CurrentDatabaseName + ''' as database_name, ''' + @dbtype + ''' as dbtype, 
-        ss.[schema_id], ss.[name] as [schema], so.[object_id], so.[name] as object_name, so.[type], so.type_desc, SUM(sps.used_page_count) AS used_page_count
-        FROM sys.objects so
-        INNER JOIN sys.dm_db_partition_stats sps ON so.[object_id] = sps.[object_id]
-        INNER JOIN sys.indexes si ON sps.[object_id] = si.[object_id] AND sps.[index_id] = si.[index_id]
-        INNER JOIN sys.schemas ss ON so.[schema_id] = ss.[schema_id]
-        LEFT JOIN sys.tables st ON so.[object_id] = st.[object_id]
-        WHERE so.[type] IN (''U'', ''V'')'
-        + CASE WHEN @Version >= 12 THEN ' AND (st.is_memory_optimized = 0 OR st.is_memory_optimized IS NULL)' ELSE '' END
-        + 'GROUP BY so.[object_id], so.[name], ss.name, ss.[schema_id], so.[type], so.type_desc'
-
-      INSERT INTO @tblObj (dbid, database_name, dbtype, schema_id, [schema], object_id, object_name, type, type_desc, used_page_count)
-      execute @CurrentDatabase_sp_executesql @stmt = @sqlcmd
-
-      --Drop Snapshot
-      IF @snapCreated = 1
-      BEGIN
-        SET @sqlcmd = 'IF EXISTS (SELECT name FROM sys.databases WHERE name = ''' + @snapName
-          + ''') AND (SELECT source_database_id FROM sys.databases WHERE name = ''' + @snapName
-          + ''') IS NOT NULL BEGIN DROP DATABASE ' + QUOTENAME(@snapName) + ' END'
-        execute sp_executesql @sqlcmd
-      END
-
-      --Update Loop Counter
-      UPDATE @tmpDatabases
-      SET Completed = 1
-      WHERE DatabaseName = @CurrentDatabaseName
-      
-      --Clear Variables
-      SET @agbit = NULL
-      SET @role = NULL
-      SET @secondaryRoleAllowConnections = NULL
-      SET @hasMemOptFG = NULL
-      SET @snapName = NULL
-      SET @snapNamePart = NULL
-      SET @snapCreated = NULL
-      SET @CurrentDatabaseName = NULL
-      SET @dbtype = NULL
-      SET @sqlcmd = NULL
-      SET @CurrentDatabase_sp_executesql = NULL
-
-    END
-    
-    --Merge into persistent table
-    MERGE master.dbo.CheckTableObjects as [Target]
-    USING (SELECT * FROM @tblObj) as [Source]
-    ON (Target.database_name = Source.database_name AND Target.[schema] = Source.[schema] AND Target.object_name = Source.object_name)
-    WHEN MATCHED /*AND Target.used_page_count <> source.used_page_count */ THEN
-        UPDATE SET Target.used_page_count = source.used_page_count, Target.Active = 1
-    WHEN NOT MATCHED BY TARGET THEN
-        INSERT ([database_name]
-          ,[dbid]
-          ,[dbtype]
-          ,[object_id]
-          ,[object_name]
-          ,[schema_id]
-          ,[schema]
-          ,[type]
-          ,[type_desc]
-          ,[used_page_count]
-          ,[Active])
-        VALUES (Source.[database_name]
-          ,Source.[dbid]
-          ,Source.[dbtype]
-          ,Source.[object_id]
-          ,Source.[object_name]
-          ,Source.[schema_id]
-          ,Source.[schema]
-          ,Source.[type]
-          ,Source.[type_desc]
-          ,Source.[used_page_count]
-          ,1)
-    WHEN NOT MATCHED BY SOURCE THEN
-        UPDATE SET Active = 0
-    ;
-
-    --Reset completed status
-    UPDATE @tmpDatabases
-    SET Completed = 0
-
-  END
-
-  ----------------------------------------------------------------------------------------------------
   --// Select check commands                                                                      //--
   ----------------------------------------------------------------------------------------------------
 
@@ -1120,11 +979,12 @@ BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The @Resumable parameter can only be used if the CHECKTABLE command is specified.', 16, 3
   END
-  -- IF @Resumable = 'Y' AND @DatabaseOrder IS NOT NULL
-  -- BEGIN
-  --   INSERT INTO @Errors ([Message], Severity, [State])
-  --   SELECT 'The @Resumable parameter will override any order specified by the @DatabaseOrder parameter.', 10, 1
-  -- END
+
+  IF @AllowSnapshots NOT IN('Y','N') OR @AllowSnapshots IS NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @AllowSnapshots must be Y or N.', 16, 1
+  END
   --------------------------------------
 
   IF EXISTS(SELECT * FROM @Errors)
@@ -1241,6 +1101,156 @@ BEGIN
   BEGIN
     SET @ReturnCode = 50000
     GOTO Logging
+  END
+
+  ----------------------------------------------------------------------------------------------------
+  --// Update Persistent Table if we need to resume operations                                    //--
+  --// This is done here so the order can be updated appropriately                                //--
+  ----------------------------------------------------------------------------------------------------
+
+  IF @Resumable = 'Y'
+  BEGIN
+    WHILE 1=1
+    BEGIN
+      SELECT TOP 1 @CurrentDatabaseName = DatabaseName,
+                   @dbtype = DatabaseType,
+                   @agbit = AvailabilityGroup
+      FROM @tmpDatabases
+      WHERE Selected = 1
+      AND Completed = 0
+
+      IF @@ROWCOUNT = 0
+      BEGIN
+        BREAK
+      END
+      SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
+     
+     --Check if we need to create a snapshot
+      IF @agbit = 1
+      BEGIN
+      	SELECT @role = s.role,
+               @secondaryRoleAllowConnections = r.secondary_role_allow_connections
+	      FROM sys.databases d
+	      JOIN sys.dm_hadr_availability_replica_states s ON d.replica_id = s.replica_id
+	      JOIN sys.availability_replicas r ON s.replica_id = r.replica_id
+        WHERE d.name = @CurrentDatabaseName
+
+        --role = 2 means secondary, secondaryRoleAllowConnections = 0 means non-readable secondary
+        IF @role = 2 and @secondaryRoleAllowConnections = 0
+        BEGIN
+          --We need a snapshot but first we need to make sure the database doesnt have mem opt tables for versions older than SQL 2019
+          IF @Version < 15
+          BEGIN
+            SET @CurrentCommand = 'IF EXISTS (SELECT * FROM sys.filegroups WHERE type = ''FX'') BEGIN SET @currentHasMemOptFG = 1 END ELSE BEGIN SET @currentHasMemOptFG = 0 END'
+            EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
+          END
+
+          IF @hasMemOptFG = 0 OR @hasMemOptFG IS NULL
+          BEGIN 
+            --Build and execute create snapshot statement
+            SET @snapNamePart = '_RollIntegChkInfo_ss_'
+            SET @snapName = @CurrentDatabaseName + @snapNamePart + CONVERT(nvarchar, @StartTime, 112)
+            SET @CurrentCommand = 'CREATE DATABASE ' + QUOTENAME(@snapName) + ' ON '
+            SELECT @CurrentCommand = @CurrentCommand + '(Name = ' + QUOTENAME(name) + ', Filename = '''
+              + physical_name --+ CASE WHEN @SnapshotPath = 'DEFAULT' THEN physical_name ELSE @SnapshotPath + '\' + name END
+              + @snapNamePart + CONVERT(nvarchar, @StartTime, 112) + '''),'
+            FROM sys.master_files WHERE database_id = DB_ID(@CurrentDatabaseName) AND type = 0
+            SET @CurrentCommand = LEFT(@CurrentCommand, LEN(@CurrentCommand) - 1)
+            SET @CurrentCommand = @CurrentCommand + ' AS SNAPSHOT OF ' + QUOTENAME(@CurrentDatabaseName)
+            EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+            SET @snapCreated = 1
+          END
+
+        END
+      END
+
+      --now that we've potentially created a snapshot, we need to use it if it was needed
+      IF @snapCreated = 1
+      BEGIN
+        SET @CurrentDatabase_sp_executesql = QUOTENAME(@snapName) + '.sys.sp_executesql'
+      END
+
+      SET @CurrentCommand = 'SELECT DB_ID(''' + @CurrentDatabaseName + ''') as dbid, ''' + @CurrentDatabaseName + ''' as database_name, ''' + @dbtype + ''' as dbtype, 
+        ss.[schema_id], ss.[name] as [schema], so.[object_id], so.[name] as object_name, so.[type], so.type_desc, SUM(sps.used_page_count) AS used_page_count
+        FROM sys.objects so
+        INNER JOIN sys.dm_db_partition_stats sps ON so.[object_id] = sps.[object_id]
+        INNER JOIN sys.indexes si ON sps.[object_id] = si.[object_id] AND sps.[index_id] = si.[index_id]
+        INNER JOIN sys.schemas ss ON so.[schema_id] = ss.[schema_id]
+        LEFT JOIN sys.tables st ON so.[object_id] = st.[object_id]
+        WHERE so.[type] IN (''U'', ''V'')'
+        + CASE WHEN @Version >= 12 THEN ' AND (st.is_memory_optimized = 0 OR st.is_memory_optimized IS NULL)' ELSE '' END
+        + 'GROUP BY so.[object_id], so.[name], ss.name, ss.[schema_id], so.[type], so.type_desc'
+
+      INSERT INTO @tblObj (dbid, database_name, dbtype, schema_id, [schema], object_id, object_name, type, type_desc, used_page_count)
+      EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+
+      --Drop Snapshot
+      IF @snapCreated = 1
+      BEGIN
+        SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
+        SET @CurrentCommand = 'IF EXISTS (SELECT name FROM sys.databases WHERE name = ''' + @snapName
+          + ''') AND (SELECT source_database_id FROM sys.databases WHERE name = ''' + @snapName
+          + ''') IS NOT NULL BEGIN DROP DATABASE ' + QUOTENAME(@snapName) + ' END'
+        EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+      END
+
+      --Update Loop Counter
+      UPDATE @tmpDatabases
+      SET Completed = 1
+      WHERE DatabaseName = @CurrentDatabaseName
+      
+      --Clear Variables
+      SET @agbit = NULL
+      SET @role = NULL
+      SET @secondaryRoleAllowConnections = NULL
+      SET @hasMemOptFG = NULL
+      SET @snapName = NULL
+      SET @snapNamePart = NULL
+      SET @snapCreated = NULL
+      SET @CurrentDatabaseName = NULL
+      SET @dbtype = NULL
+      SET @CurrentCommand = NULL
+      SET @CurrentDatabase_sp_executesql = NULL
+
+    END
+    
+    --Merge into persistent table
+    MERGE master.dbo.CheckTableObjects as [Target]
+    USING (SELECT * FROM @tblObj) as [Source]
+    ON (Target.database_name = Source.database_name AND Target.[schema] = Source.[schema] AND Target.object_name = Source.object_name)
+    WHEN MATCHED /*AND Target.used_page_count <> source.used_page_count */ THEN
+        UPDATE SET Target.used_page_count = source.used_page_count, Target.Active = 1
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT ([database_name]
+          ,[dbid]
+          ,[dbtype]
+          ,[object_id]
+          ,[object_name]
+          ,[schema_id]
+          ,[schema]
+          ,[type]
+          ,[type_desc]
+          ,[used_page_count]
+          ,[Active])
+        VALUES (Source.[database_name]
+          ,Source.[dbid]
+          ,Source.[dbtype]
+          ,Source.[object_id]
+          ,Source.[object_name]
+          ,Source.[schema_id]
+          ,Source.[schema]
+          ,Source.[type]
+          ,Source.[type_desc]
+          ,Source.[used_page_count]
+          ,1)
+    WHEN NOT MATCHED BY SOURCE THEN
+        UPDATE SET Active = 0
+    ;
+
+    --Reset completed status
+    UPDATE @tmpDatabases
+    SET Completed = 0
+
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -1861,33 +1871,36 @@ BEGIN
       -- Check objects
       IF EXISTS(SELECT * FROM @SelectedCheckCommands WHERE CheckCommand = 'CHECKTABLE') AND (SYSDATETIME() < @EndTime OR @TimeLimit IS NULL)
       BEGIN
-        --We need a snapshot but first we need to make sure the database doesnt have mem opt tables for versions older than SQL 2019
-        IF @Version < 15
+      IF @AllowSnapshots = 'Y'
         BEGIN
-          set @sqlcmd = 'IF EXISTS (SELECT * FROM sys.filegroups WHERE type = ''FX'') BEGIN SET @currentHasMemOptFG = 1 END ELSE BEGIN SET @currentHasMemOptFG = 0 END'
-          execute @CurrentDatabase_sp_executesql @stmt = @sqlcmd, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
-        END
+          --We need a snapshot but first we need to make sure the database doesnt have mem opt tables for versions older than SQL 2019
+          IF @Version < 15
+          BEGIN
+            SET @CurrentCommand = 'IF EXISTS (SELECT * FROM sys.filegroups WHERE type = ''FX'') BEGIN SET @currentHasMemOptFG = 1 END ELSE BEGIN SET @currentHasMemOptFG = 0 END'
+            EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
+          END
 
-        --We can't take snapshots of system databases (other than msdb but we don't want to anyway)
-        IF @dbtype = 'U' AND (@hasMemOptFG = 0 OR @hasMemOptFG IS NULL)
-          BEGIN 
-            --Build and execute create snapshot statement
-            SET @snapNamePart = '_CHKTABLE_ss_'
-            SET @snapName = @CurrentDatabaseName + @snapNamePart + CONVERT(nvarchar, @StartTime, 112)
-            SET @sqlcmd = 'CREATE DATABASE ' + QUOTENAME(@snapName) + ' ON '
-            SELECT @sqlcmd = @sqlcmd + '(Name = ' + QUOTENAME(name) + ', Filename = '''
-              + physical_name --+ CASE WHEN @SnapshotPath = 'DEFAULT' THEN physical_name ELSE @SnapshotPath + '\' + name END
-              + @snapNamePart + CONVERT(nvarchar, @StartTime, 112) + '''),'
-            FROM sys.master_files WHERE database_id = DB_ID(@CurrentDatabaseName) AND type = 0
-            SET @sqlcmd = LEFT(@sqlcmd, LEN(@sqlcmd) - 1)
-            SET @sqlcmd = @sqlcmd + ' AS SNAPSHOT OF ' + QUOTENAME(@CurrentDatabaseName)
-            EXEC sp_executesql @sqlcmd
-            SET @snapCreated = 1
-        END
+          --We can't take snapshots of system databases (other than msdb but we don't want to anyway)
+          IF @dbtype = 'U' AND (@hasMemOptFG = 0 OR @hasMemOptFG IS NULL)
+            BEGIN 
+              --Build and execute create snapshot statement
+              SET @snapNamePart = '_CHKTABLE_ss_'
+              SET @snapName = @CurrentDatabaseName + @snapNamePart + CONVERT(nvarchar, @StartTime, 112)
+              SET @CurrentCommand = 'CREATE DATABASE ' + QUOTENAME(@snapName) + ' ON '
+              SELECT @CurrentCommand = @CurrentCommand + '(Name = ' + QUOTENAME(name) + ', Filename = '''
+                + physical_name --+ CASE WHEN @SnapshotPath = 'DEFAULT' THEN physical_name ELSE @SnapshotPath + '\' + name END
+                + @snapNamePart + CONVERT(nvarchar, @StartTime, 112) + '''),'
+              FROM sys.master_files WHERE database_id = DB_ID(@CurrentDatabaseName) AND type = 0
+              SET @CurrentCommand = LEFT(@CurrentCommand, LEN(@CurrentCommand) - 1)
+              SET @CurrentCommand = @CurrentCommand + ' AS SNAPSHOT OF ' + QUOTENAME(@CurrentDatabaseName)
+              EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+              SET @snapCreated = 1
+          END
 
-        IF @snapCreated = 1
-        BEGIN
-          SET @CurrentDatabase_sp_executesql = QUOTENAME(@snapName) + '.sys.sp_executesql'
+          IF @snapCreated = 1
+          BEGIN
+            SET @CurrentDatabase_sp_executesql = QUOTENAME(@snapName) + '.sys.sp_executesql'
+          END
         END
         
         SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT schemas.[schema_id] AS SchemaID, schemas.[name] AS SchemaName, objects.[object_id] AS ObjectID, objects.[name] AS ObjectName, RTRIM(objects.[type]) AS ObjectType, 0 AS [Order], 0 AS Selected, 0 AS Completed FROM sys.objects objects INNER JOIN sys.schemas schemas ON objects.schema_id = schemas.schema_id LEFT OUTER JOIN sys.tables tables ON objects.object_id = tables.object_id WHERE objects.[type] IN(''U'',''V'') AND EXISTS(SELECT * FROM sys.indexes indexes WHERE indexes.object_id = objects.object_id)' + CASE WHEN @Version >= 12 THEN ' AND (tables.is_memory_optimized = 0 OR is_memory_optimized IS NULL)' ELSE '' END + ' ORDER BY schemas.name ASC, objects.name ASC'
@@ -2175,6 +2188,16 @@ BEGIN
       AND ID = @CurrentDBID
     END
 
+    --Drop Snapshot
+    IF @snapCreated = 1
+    BEGIN
+      SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
+      SET @CurrentCommand = 'IF EXISTS (SELECT name FROM sys.databases WHERE name = ''' + @snapName
+        + ''') AND (SELECT source_database_id FROM sys.databases WHERE name = ''' + @snapName
+        + ''') IS NOT NULL BEGIN DROP DATABASE ' + QUOTENAME(@snapName) + ' END'
+      EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+    END
+
     -- Clear variables
     SET @CurrentDBID = NULL
     SET @CurrentDatabaseName = NULL
@@ -2200,20 +2223,10 @@ BEGIN
     SET @CurrentCommandType = NULL
 
     --Additions------------
-    --Drop Snapshot
-    IF @snapCreated = 1
-    BEGIN
-      SET @sqlcmd = 'IF EXISTS (SELECT name FROM sys.databases WHERE name = ''' + @snapName
-        + ''') AND (SELECT source_database_id FROM sys.databases WHERE name = ''' + @snapName
-        + ''') IS NOT NULL BEGIN DROP DATABASE ' + QUOTENAME(@snapName) + ' END'
-      execute sp_executesql @sqlcmd
-    END
-
     SET @hasMemOptFG = NULL
     SET @snapName = NULL
     SET @snapCreated = NULL
     SET @dbtype = NULL
-    SET @sqlcmd = NULL
     ------------------------
 
     DELETE FROM @tmpFileGroups

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -737,12 +737,14 @@ BEGIN
 
 
     --now that we've potentially created a snapshot, we need to use it if it was needed
+    IF @snapCreated = 1
+    BEGIN SET @CurrentDatabase_sp_executesql = QUOTENAME(@snapName) + '.sys.sp_executesql' END
 
 
 
 
 
-      SET @sqlcmd = 'USE ' + QUOTENAME(@CurrentDatabaseName) + ' SELECT DB_ID() as dbid, DB_NAME() as database_name, ''' + @dbtype + ''' as dbtype, 
+      SET @sqlcmd = 'SELECT DB_ID() as dbid, DB_NAME() as database_name, ''' + @dbtype + ''' as dbtype, 
       ss.[schema_id], ss.[name] as [schema], so.[object_id], so.[name] as object_name, so.[type], so.type_desc, SUM(sps.used_page_count) AS used_page_count
       FROM sys.objects so
       INNER JOIN sys.dm_db_partition_stats sps ON so.[object_id] = sps.[object_id]
@@ -754,7 +756,7 @@ BEGIN
       + 'GROUP BY so.[object_id], so.[name], ss.name, ss.[schema_id], so.[type], so.type_desc'
 
       INSERT INTO @tblObj (dbid, database_name, dbtype, schema_id, [schema], object_id, object_name, type, type_desc, used_page_count)
-      EXEC sp_executesql @sqlcmd
+      execute @CurrentDatabase_sp_executesql @stmt = @sqlcmd
 
       --Clear Variables
       SET @agbit = NULL

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -1142,7 +1142,7 @@ BEGIN
           IF @Version < 15
           BEGIN
             SET @CurrentCommand = 'IF EXISTS (SELECT * FROM sys.filegroups WHERE type = ''FX'') BEGIN SET @currentHasMemOptFG = 1 END ELSE BEGIN SET @currentHasMemOptFG = 0 END'
-            EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
+            EXECUTE sp_executesql @stmt = @CurrentCommand, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
           END
 
           IF @hasMemOptFG = 0 OR @hasMemOptFG IS NULL
@@ -1157,7 +1157,7 @@ BEGIN
             FROM sys.master_files WHERE database_id = DB_ID(@CurrentDatabaseName) AND type = 0
             SET @CurrentCommand = LEFT(@CurrentCommand, LEN(@CurrentCommand) - 1)
             SET @CurrentCommand = @CurrentCommand + ' AS SNAPSHOT OF ' + QUOTENAME(@CurrentDatabaseName)
-            EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+            EXECUTE sp_executesql @stmt = @CurrentCommand
             SET @snapCreated = 1
           END
 
@@ -1187,11 +1187,10 @@ BEGIN
       --Drop Snapshot
       IF @snapCreated = 1
       BEGIN
-        SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
         SET @CurrentCommand = 'IF EXISTS (SELECT name FROM sys.databases WHERE name = ''' + @snapName
           + ''') AND (SELECT source_database_id FROM sys.databases WHERE name = ''' + @snapName
           + ''') IS NOT NULL BEGIN DROP DATABASE ' + QUOTENAME(@snapName) + ' END'
-        EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+        EXECUTE sp_executesql @stmt = @CurrentCommand
       END
 
       --Update Loop Counter
@@ -1877,7 +1876,7 @@ BEGIN
           IF @Version < 15
           BEGIN
             SET @CurrentCommand = 'IF EXISTS (SELECT * FROM sys.filegroups WHERE type = ''FX'') BEGIN SET @currentHasMemOptFG = 1 END ELSE BEGIN SET @currentHasMemOptFG = 0 END'
-            EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
+            EXECUTE sp_executesql @stmt = @CurrentCommand, @params = N'@currentHasMemOptFG bit OUTPUT', @currentHasMemOptFG = @hasMemOptFG OUTPUT
           END
 
           --We can't take snapshots of system databases (other than msdb but we don't want to anyway)
@@ -1893,7 +1892,7 @@ BEGIN
               FROM sys.master_files WHERE database_id = DB_ID(@CurrentDatabaseName) AND type = 0
               SET @CurrentCommand = LEFT(@CurrentCommand, LEN(@CurrentCommand) - 1)
               SET @CurrentCommand = @CurrentCommand + ' AS SNAPSHOT OF ' + QUOTENAME(@CurrentDatabaseName)
-              EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+              EXECUTE sp_executesql @stmt = @CurrentCommand
               SET @snapCreated = 1
           END
 
@@ -2191,11 +2190,10 @@ BEGIN
     --Drop Snapshot
     IF @snapCreated = 1
     BEGIN
-      SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
       SET @CurrentCommand = 'IF EXISTS (SELECT name FROM sys.databases WHERE name = ''' + @snapName
         + ''') AND (SELECT source_database_id FROM sys.databases WHERE name = ''' + @snapName
         + ''') IS NOT NULL BEGIN DROP DATABASE ' + QUOTENAME(@snapName) + ' END'
-      EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
+      EXECUTE sp_executesql @stmt = @CurrentCommand
     END
 
     -- Clear variables

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Custom Solution
-Main differences are in the DatabaseIntegrityCheck script and added the CheckTableObjects table
+Main differences are in the DatabaseIntegrityCheck script and added the CheckTableObjects table<br><br>
+ Differences:
+  - Runs CheckAlloc, then CheckCatalog, then CheckTable
+    - This is a different order than original Ola, which was CheckAlloc, CheckTable, CheckCatalog
+  - For CHECKTABLE command, it will always take a manual database snapshot, as that allows for faster runs, especially on larger databases.
+  - The @Resumable parameter will store info in the CheckTableObjects table and goes through the objects in a rolling fashion, thus allowing for the checking of VLDBs without the need for a large window to run CHECKDB
 
 Added Parameters:<br>
  - @Resumable - valid values are 'Y' or 'N'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Custom Solution
+Main differences are in the DatabaseIntegrityCheck script and added the CheckTableObjects table
+
+Added Parameters:<br>
+ - @Resumable - valid values are 'Y' or 'N'
+   - defaults to 'N'
+   - Must be used in conjunction with @TimeLimit
+    - Can only be used if the CheckTable command is specified
+
 # SQL Server Maintenance Solution
 [![licence badge]][licence]
 [![stars badge]][stars]

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ Main differences are in the DatabaseIntegrityCheck script and added the CheckTab
 
 Added Parameters:<br>
  - @Resumable - valid values are 'Y' or 'N'
-    - defaults to 'N'
-    - Must be used in conjunction with @TimeLimit
-    - Can only be used if the CheckTable command is specified
-    - Runs CheckAlloc, then CheckCatalog, then CheckTable
-      - This is a different order than original Ola, which was CheckAlloc, CheckTable, CheckCatalog
-    - Will only run CHECKTABLE checks once per day, as it makes sure that "dbo.CheckTableObjects.LastCheckDate <> CAST(@StartTime as date)"
-      - This is to prevent a loop of it just going through the same tables over and over during the time window
-      - To reset either Truncate the CheckTableObjects table, or update LastCheckDate to an older date
-        - ```UPDATE dbo.CheckTableObjects SET LastCheckDate = DATEADD(DAY, -1, LastCheckDate) ```
+   - defaults to 'N'
+   - Must be used in conjunction with @TimeLimit
+   - Can only be used if the CheckTable command is specified
+   - Will only run CHECKTABLE checks once per day, as it makes sure that "dbo.CheckTableObjects.LastCheckDate <> CAST(@StartTime as date)"
+     - This is to prevent a loop of it just going through the same tables over and over during the time window
+     - To reset either Truncate the CheckTableObjects table, or update LastCheckDate to an older date
+       - ```UPDATE dbo.CheckTableObjects SET LastCheckDate = DATEADD(DAY, -1, LastCheckDate) ```
+ - @AllowSnapshots - valid values are 'Y' or 'N'
+   - Defaults to 'Y'
+   - Allows the script to take it's own snapshot for the CHECKTABLE command to allow for faster operation.  Otherwise, the CHECKTABLE commad will create an internal snapshot for each command that it runs, which creates much more overhead, especially on larger databases
+   - Also allows for checking non-readable secondaries when the database is in an availability group.
 
 Example:
 ```sql    

--- a/README.md
+++ b/README.md
@@ -3,10 +3,20 @@ Main differences are in the DatabaseIntegrityCheck script and added the CheckTab
 
 Added Parameters:<br>
  - @Resumable - valid values are 'Y' or 'N'
-   - defaults to 'N'
-   - Must be used in conjunction with @TimeLimit
+    - defaults to 'N'
+    - Must be used in conjunction with @TimeLimit
     - Can only be used if the CheckTable command is specified
+    - Runs CheckAlloc, then CheckCatalog, then CheckTable
+      - This is a different order than original Ola, which was CheckAlloc, CheckTable, CheckCatalog
+    - Will only run CHECKTABLE checks once per day, as it makes sure that "dbo.CheckTableObjects.LastCheckDate <> CAST(@StartTime as date)"
+      - This is to prevent a loop of it just going through the same tables over and over during the time window
+      - To reset either Truncate the CheckTableObjects table, or update LastCheckDate to an older date
+        - ```UPDATE dbo.CheckTableObjects SET LastCheckDate = DATEADD(DAY, -1, LastCheckDate) ```
 
+Example:
+```sql    
+EXECUTE [dbo].[DatabaseIntegrityCheck] @Databases = 'ALL_DATABASES', @CheckCommands = 'CHECKALLOC,CHECKCATALOG,CHECKTABLE', @TimeLimit = 18000, @LogToTable = 'Y', @Execute = 'Y', @Resumable = 'Y'
+```
 # SQL Server Maintenance Solution
 [![licence badge]][licence]
 [![stars badge]][stars]


### PR DESCRIPTION
This allows for faster runtimes as well as the ability to run CHECKTABLE against non-readable secondaries in an AG